### PR TITLE
Fix Day#pad returning nil when no padding needed

### DIFF
--- a/lib/day.rb
+++ b/lib/day.rb
@@ -1,6 +1,6 @@
 # Helper for days
 class Day
   def self.pad(day)
-    '0' + day if day.to_i < 10
+    '%02d' % day
   end
 end


### PR DESCRIPTION
First of all, thanks for a great tool - it makes my experience with AoC much smoother!

I started doing a few of previous years' problems today and noticed that something related to the padding seems to be out of order when the number contains two digits. I bootstrapped day 22 of 2015 and noticed that both the file and class names generated omitted the number.

The culprit seems to be the `Day#pad` method, which returns nil if no padding is needed. I have updated the method to work with both.

Before: 
```
irb(main):001:0> require './lib/day'
=> true
irb(main):002:0> Day.pad("5")
=> "05"
irb(main):003:0> Day.pad("15")
=> nil
```

After:
```
irb(main):001:0> require './lib/day'
=> true
irb(main):002:0> Day.pad("5")
=> "05"
irb(main):003:0> Day.pad("15")
=> "15"
```

I am on `ruby 2.6.5p114`  `.ruby-version`.