### PR TITLE
Update HTTParty code to use HTTPS and a custom User-Agent header

### DIFF
--- a/lib/aoc_api.rb
+++ b/lib/aoc_api.rb
@@ -1,11 +1,17 @@
 # HTTP API for downloading puzzles
 class AocApi
   include HTTParty
-  base_uri 'adventofcode.com'
+  base_uri 'https://adventofcode.com'
 
   def initialize(year, session)
     @year = year
-    @options = { headers: { 'Cookie' => "session=#{session}" } }
+    @options = {
+      headers:
+        {
+          'Cookie' => "session=#{session}",
+          'User-Agent' => 'github.com/Keirua/aoc-cli by clement@keiruaprod.fr'
+        }
+    }
   end
 
   def day(day_number)


### PR DESCRIPTION
As per [this announcement](https://old.reddit.com/r/adventofcode/comments/z9dhtd/please_include_your_contact_info_in_the_useragent/), tools which use a generic `User-Agent` header might be blocked soon. I've updated the code to use a custom header on the format suggested in the announcement.

I also noticed when using the debugging mode of HTTParty that the site redirects non-HTTPS requests so I set the base URI to HTTPS to avoid an extra request.

No need to update for my sake as I have my own fork but feel free to merge if it helps you or anyone else!